### PR TITLE
Please cut an NPM release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { "name" : "couchapp"
 , "description" : "Utilities for building CouchDB applications."
 , "tags" : ["couchdb", "webframework"]
-, "version" : "0.8.1"
+, "version" : "0.8.2"
 , "author" : "Mikeal Rogers <mikeal.rogers@gmail.com>"
 , "engines" : ["node >= 0.1.95"]
 , "main" : "./main"


### PR DESCRIPTION
Hi, Mikeal.

I'm working on a Kanso branch to make it Catholic, i.e. installable via npm and only depending packages in NPM. Currently they have a Git submodule of node.couchapp.js, with bugfixes committed after the latest NPM publish.

Would you mind publishing a new release so Kanso can use the code it expects but I can pull it from the NPM registry? I went ahead and bumped the version for you.
