### PR TITLE
line 183 - makes attachment work on windows.

### DIFF
--- a/main.js
+++ b/main.js
@@ -180,7 +180,7 @@ function createApp (doc, url, cb) {
         var pending_files = Object.keys(files).length;
         for (i in files) { (function (f) {
           fs.readFile(f, function (err, data) {
-            f = f.replace(att.root, att.prefix || '');
+            f = f.replace(att.root, att.prefix || '').replace(/\\/g,"/");
             if (f[0] == '/') f = f.slice(1)
             if (!err) {
               var d = data.toString('base64')


### PR DESCRIPTION
Windows paths come with back-slashes, and that craps the attachments part.

After trying a boiler project and pushing it - I could not get /index.html - error message was of missing attachement.

all files in the attachments section begun with "\" and was not accessible to web requests like they should be.
copmaring the design document with some public design documents I found - I saw that the paths are expected with normal slashes, so I figured it's a path problem.

The fix is checked on WinXP, with GoW(0.4.0), Node(0.6.9) and couchapp from the NPM (together with pull request #43).
