### PR TITLE
setting mimetype for App Cache files = Happy HTML5 coders

### DIFF
--- a/mimetypes.js
+++ b/mimetypes.js
@@ -1,6 +1,7 @@
 // from http://github.com/felixge/node-paperboy
 exports.types = {
   "aiff":"audio/x-aiff",
+  "appcache":"text/cache-manifest",
   "arj":"application/x-arj-compressed",
   "asf":"video/x-ms-asf",
   "asx":"video/x-ms-asx",


### PR DESCRIPTION
Setting the mimetype correctly for App Cache files will help people writing CouchApps that want to take advantage of the new App Cache features in browsers.  If this mimetype isn't set correctly, browsers will ignore manifest files :(.  
