### PR TITLE
Correctly set pending_dirs to support walking subdirectories

### DIFF
--- a/main.js
+++ b/main.js
@@ -180,10 +180,10 @@ function createApp (doc, url, cb) {
       coffeeCompile = require('coffee-script');
       coffeeExt = /\.(lit)?coffee$/;
     } catch(e){}
-    
-    pending_dirs = app.doc.__attachments.length;
+
     app.doc.__attachments.forEach(function (att) {
       watch.walk(att.root, {ignoreDotFiles:true}, function (err, files) {
+        pending_dirs += 1;
         var pending_files = Object.keys(files).length;
         for (i in files) { (function (f) {
           fs.readFile(f, function (err, data) {


### PR DESCRIPTION
I noticed when running couchapp that sometimes I wouldn't get all of my attachments, especially the ones in subdirectories.

I tracked this down to the attached code; the callback from `push` gets called whenever `pending_dirs` is zero, but it doesn't take in to account that the callback from `watch.walk` could happen more times than there are attachments.
