### PR TITLE
Only play sound if you can play sound

### DIFF
--- a/main.js
+++ b/main.js
@@ -111,7 +111,11 @@ function copy (obj) {
 }
 
 function playSound () {
-  spawn("/usr/bin/afplay", ["/System/Library/Sounds/Blow.aiff"]);
+  fs.exists("/usr/bin/afplay", function (exists) {
+    if (exists === true) {
+      spawn("/usr/bin/afplay", ["/System/Library/Sounds/Blow.aiff"]);
+    }
+  })
 }
   
 function createApp (doc, url, cb) {


### PR DESCRIPTION
On my Raspberry Pi (and surely on other devices) the file `/usr/bin/afplay` does not exist. This pull request makes couchapp check to see if the machine that it's running on has that file, and if it does, then it will work like normally, but if it doesn't (like in the case of my Raspberry Pi), then it won't bother trying to play the sound (instead of failing)
