### PR TITLE
Display usage message for unknown commands

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -133,11 +133,7 @@ if (process.mainModule && process.mainModule.filename === __filename) {
       ].join('\n')
     )
 
-    if (command === 'help') {
-      process.exit(0);
-    } else {
-      process.exit(1);
-    }
+    command === 'help' ? process.exit(0) : process.exit(1);
   }
 
   if (couch == undefined) {

--- a/bin.js
+++ b/bin.js
@@ -42,8 +42,6 @@ function boiler (app) {
   app = app || '.'
 
   copytree(path.join(__dirname, 'boiler'), path.join(process.cwd(), app));
-
-
 }
 
 
@@ -52,16 +50,18 @@ function onBeforePushSync() {
     beforePushSyncListener.onBeforePushSync();
   }
 }
+
 function onAfterPushSync() {
   if (afterPushSyncListener && typeof afterPushSyncListener.onAfterPushSync === "function") {
     afterPushSyncListener.onAfterPushSync();
   }
 }
+
 var _isUsingDirectoryConfig;
 function isUsingDirectoryConfig() {
   if(_isUsingDirectoryConfig != null)
     return _isUsingDirectoryConfig;
-  return _isUsingDirectoryConfig = (process.argv[2].trim() === "-dc");
+  return _isUsingDirectoryConfig = (process.argv[2] && process.argv[2].trim() === "-dc");
 }
 
 if (process.mainModule && process.mainModule.filename === __filename) {
@@ -110,7 +110,7 @@ if (process.mainModule && process.mainModule.filename === __filename) {
     couch = process.argv.shift();
   }
 
-  if (command == 'help' || command == undefined) {
+  if (['push', 'sync', 'boiler', 'serve'].indexOf(command) < 0) {
     console.log(
       [ "couchapp -- utility for creating couchapps"
         , ""
@@ -121,6 +121,7 @@ if (process.mainModule && process.mainModule.filename === __filename) {
         , " couchapp -dc <command> <appconfigdirectory> http://localhost:5984/dbname"
         , ""
         , "Commands:"
+        , "  help   : Show this help message and exit."
         , "  push   : Push app once to server."
         , "  sync   : Push app then watch local files for changes."
         , "  boiler : Create a boiler project."
@@ -129,12 +130,16 @@ if (process.mainModule && process.mainModule.filename === __filename) {
         , "            -p port  : list on port portNum [default=3000]"
         , "            -d dir   : attachments directory [default='attachments']"
         , "            -l       : log rewrites to couchdb [default='false']"
-      ]
-      .join('\n')
+      ].join('\n')
     )
-    process.exit();
+
+    if (command === 'help') {
+      process.exit(0);
+    } else {
+      process.exit(1);
+    }
   }
-  
+
   if (couch == undefined) {
     try {
       couch = JSON.parse(fs.readFileSync('.couchapp.json')).couch;
@@ -176,7 +181,6 @@ if (process.mainModule && process.mainModule.filename === __filename) {
         if (command == 'push') app.push()
         else if (command == 'sync') app.sync()
         else if (command == 'serve') serve(app);
-        
       })
     }
   }


### PR DESCRIPTION
This is the first thing I tried with the binary:

```
% couchapp --help

/usr/local/lib/node_modules/couchapp/bin.js:10
  if (pathname[0] === '/') return pathname
              ^
TypeError: Cannot read property '0' of undefined
    at abspath (/usr/local/lib/node_modules/couchapp/bin.js:10:15)
    at Object.<anonymous> (/usr/local/lib/node_modules/couchapp/bin.js:78:32)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:901:3
```

I assume others may attempt to do this at some point and be greeted by the same unfriendly error message. This small patch adds a little bit of handling for those situations and keeps things friendly.

Any commands that aren't recognized (ie. `couchapp fail`) trigger the usage message to be displayed and exit with a `1` status code. `help` triggers the usage message but exits with a `0` status code. I didn't add the `--help` or `-h` flags because I was trying to follow the format. 
