### PR TITLE
report status codes on failure

### DIFF
--- a/main.js
+++ b/main.js
@@ -152,7 +152,9 @@ function createApp (doc, url, cb) {
     console.log('PUT '+url.replace(/^(https?:\/\/[^@:]+):[^@]+@/, '$1:******@'))
     request({uri:url, method:'PUT', body:body, headers:h}, function (err, resp, body) {
       if (err) throw err;
-      if (resp.statusCode !== 201) throw new Error("Could not push document\n"+body)
+      if (resp.statusCode !== 201) {
+        throw new Error("Could not push document\nCode: " + resp.statusCode + "\n"+body);
+      }
       app.doc._rev = JSON.parse(body).rev
       console.log('Finished push. '+app.doc._rev)
       playSound();


### PR DESCRIPTION
Some errors, such as 413, do not respond with anything in the body, and are thus only diagnosable given the status code. This changes the error message to add the status code to the readout.
