### PR TITLE
Update bin.js

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -61,7 +61,7 @@ var _isUsingDirectoryConfig;
 function isUsingDirectoryConfig() {
   if(_isUsingDirectoryConfig != null)
     return _isUsingDirectoryConfig;
-  return _isUsingDirectoryConfig = (process.argv[2].trim() === "-dc");
+  return _isUsingDirectoryConfig = (process.argv[2] && (process.argv[2].trim() === "-dc"));
 }
 
 if (process.mainModule && process.mainModule.filename === __filename) {


### PR DESCRIPTION
To cure this problem:

$ couchapp

/usr/lib/node_modules/couchapp/bin.js:64
  return _isUsingDirectoryConfig = (process.argv[2].trim() === "-dc");
                                                    ^
TypeError: Cannot call method 'trim' of undefined
    at isUsingDirectoryConfig (/usr/lib/node_modules/couchapp/bin.js:64:53)
    at Object.<anonymous> (/usr/lib/node_modules/couchapp/bin.js:81:7)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:901:3

change line 64 to check for any argv[2]:

  return _isUsingDirectoryConfig = (process.argv[2] && (process.argv[2].trim() === "-dc"));
