### PR TITLE
Fix loadFiles to allow multiple periods in file names.

### DIFF
--- a/main.js
+++ b/main.js
@@ -70,7 +70,7 @@ function loadFiles(dir, options) {
 
   listings.forEach(function (listing) {
     var file = path.join(dir, listing)
-      , prop = listing.split('.')[0] // probably want regexp or something more robust
+      , prop = listing.split('.').slice(0, -1).join('.') // probably want regexp or something more robust
       , stat = fs.statSync(file);
 
       if (stat.isFile()) { 


### PR DESCRIPTION
This give slightly better file handling to loadFiles.

The existing code won't load files named with multiple "." properly. Something like "stuff.here.js" ends up with prop = "stuff". This will at least make it prop = "stuff.here"
