### PR TITLE
Don't play the horn on push

### DIFF
--- a/main.js
+++ b/main.js
@@ -110,13 +110,6 @@ function copy (obj) {
   return n
 }
 
-function playSound () {
-  fs.exists("/usr/bin/afplay", function (exists) {
-    if (exists === true) {
-      spawn("/usr/bin/afplay", ["/System/Library/Sounds/Blow.aiff"]);
-    }
-  })
-}
   
 function createApp (doc, url, cb) {
   var app = {doc:doc}
@@ -157,7 +150,6 @@ function createApp (doc, url, cb) {
       }
       app.doc._rev = JSON.parse(body).rev
       console.log('Finished push. '+app.doc._rev)
-      playSound();
       request({uri:url, headers:h}, function (err, resp, body) {
         body = JSON.parse(body);
         app.doc._attachments = body._attachments;


### PR DESCRIPTION
I use this for the npm registry, and the horn blow gets incredibly annoying when running tests.

So much so, in fact, that it is a disincentive to create or run tests for the npm registry couchapp, leading to production downtime for the entire Node.js community.

Please consider removing it.

An alternative may be to allow the user to specify a sound file to play on push.  But really, this is an unnecessarily presumptuous and literally noisy feature.  I can understand the benefit if you had a background sync running, but even then, since sync's usually take less than a second, you can usually just assume it worked.
