### PR TITLE
Hardcode http-proxy version to fix `serve` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "watch": "~0.8.0",
     "request": "*",
-    "http-proxy": "*",
+    "http-proxy": "0.8.7",
     "connect": "*",
     "nano": "*",
     "url": "*",


### PR DESCRIPTION
The http-proxy module has changed. Hardcoding to the old version when `serve` was originally developed. It works, as in it doesn't result in a crash anymore, but I'm still not sure about the utility of `serve`. It's kind of pointless if your CouchApp can't access the CouchDB right?
