### PR TITLE
Update for new http-proxy API

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -242,7 +242,7 @@ function serve(app) {
   } catch(e) {}
 
 
-  var proxy = new httpProxy.HttpProxy({
+  var proxy = httpProxy.createProxyServer({
     target: {
       host: dbUrlObj.host,
       hostname: dbUrlObj.hostname,


### PR DESCRIPTION
`node.couchapp.js` had an asterisks in its `package.json` for `http-proxy`,
which updated its API. New installs of
`node.couchapp.js break` as a result. This patch updates `bin.js` to the
new API.

The alternative, I guess is to go back though the versions of of `http-proxy`, figure out when the switch happened, and lock in that version. This seemed more straight-forward.

That said, we may want to lock in the version numbers for `node.couchapp.js`'s dependencies to prevent this from happening in the future. Thoughts?
