### PR TITLE
Add repository url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,9 @@
   },
   "bin": {
     "couchapp": "./bin.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mikeal/node.couchapp.js"
   }
 }


### PR DESCRIPTION
In order to have a clickable link to the repository on npm-www,
the npm webapp
