### PR TITLE
refactor interface between ./bin and ./main

### DIFF
--- a/main.js
+++ b/main.js
@@ -152,14 +152,14 @@ function createApp (doc, cb) {
     delete doc.__attachments;
     var body = JSON.stringify(doc)
     console.log('PUT '+url.replace(/^(https?:\/\/[^@:]+):[^@]+@/, '$1:******@'))
-    request({uri:url, method:'PUT', body:body, headers:h}, function (err, resp, body) {
+    request({uri:url, method:'PUT', body:body, headers:h()}, function (err, resp, body) {
       if (err) return reject(err,callback);
       if (resp.statusCode !== 201) {
         return reject(new Error("Could not push document\nCode: " + resp.statusCode + "\n"+body),callback);
       }
       app.doc._rev = JSON.parse(body).rev
       console.log('Finished push. '+app.doc._rev)
-      request({uri:url, headers:h}, function (err, resp, body) {
+      request({uri:url, headers:h()}, function (err, resp, body) {
         body = JSON.parse(body);
         app.doc._attachments = body._attachments;
         if (callback) callback()
@@ -319,7 +319,7 @@ function createApp (doc, cb) {
       url = toUrl;
       if (url.slice(url.length - _id.length) !== _id) url += '/' + _id;
 
-      request({uri:url, headers:h}, function (err, resp, body) {
+      request({uri:url, headers:h()}, function (err, resp, body) {
         if (err) throw err;
         if (resp.statusCode == 404) app.current = {};
         else if (resp.statusCode !== 200) return reject(new Error("Failed to get doc\n"+body));


### PR DESCRIPTION
refactor interface between `./bin` and `./main` so that `./main` can be
required and used "programattically" to push apps as using JS code, and not CLI.

The motive for the PR is this project: https://github.com/osher/ddocs
which currently has a manipulated copy of `main.js`, but I would love to discard it and use the original one, once if and when this PR is accepted.
*Disclaimer re. `ddocs` - although I have more work on the test suite and on the docs, the itself package is working and is used in our CI flow.
However, since it does not contain any secret sauce - we decided to feature the utility as open source.*

The essence of this PR is the changes I had to do on the copy of `./main.js` in https://github.com/osher/ddocs, and the matching counterparts in `./bin.js`

The PR is associated with the following issue:  https://github.com/mikeal/node.couchapp.js/issues/104


Thanks,  
    O